### PR TITLE
Add i18n dictionary and localize UI copy

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 // src/app/blog/[slug]/page.tsx
 
-import type { Metadata } from 'next'
+import type { Metadata } from "next";
 
 import fs from "fs";
 import path from "path";
@@ -15,6 +15,7 @@ import remarkMath from "remark-math";
 
 import { Clock } from "@/components/Clock";
 import { Header } from "@/components/Header";
+import { DEFAULT_LOCALE, getDictionary } from "@/i18n/dictionaries";
 import { Post } from "@/types";
 
 const getPost = async (slug: string): Promise<Post> => {
@@ -65,9 +66,9 @@ export async function generateMetadata({ params }: { params: { slug: string } })
           url: post.image,
           width: 1200,
           height: 630,
-          alt: '',
-        }
-      ]
+          alt: "",
+        },
+      ],
     },
     twitter: {
       images: [
@@ -75,24 +76,29 @@ export async function generateMetadata({ params }: { params: { slug: string } })
           url: post.image,
           width: 800,
           height: 418,
-          alt: '',
-        }
-      ]
+          alt: "",
+        },
+      ],
     },
-    metadataBase: new URL('https://ianaraujo.com')
+    metadataBase: new URL("https://ianaraujo.com"),
   };
 }
 
 const PostPage = async ({ params }: { params: { slug: string } }) => {
   const { slug } = params;
   const post = await getPost(slug);
+  const lang = DEFAULT_LOCALE;
+  const dictionary = getDictionary(lang);
 
   return (
     <div className="flex justify-center w-full min-h-screen">
       <div className="mt-10 w-full max-w-screen-md px-8 md:px-0">
-        <Header />
+        <Header dictionary={dictionary.header} />
         <div className="flex flex-col space-y-5 mb-10">
-          <p className="w-fit px-2 py-[2px] bg-zinc-200 text-zinc-800 text-sm rounded">
+          <p
+            className="w-fit px-2 py-[2px] bg-zinc-200 text-zinc-800 text-sm rounded"
+            aria-label={`${dictionary.post.tagLabel}: ${post.tag}`}
+          >
             {post.tag}
           </p>
           <h1 className="text-4xl font-bold leading-tight">{post.title}</h1>
@@ -101,7 +107,9 @@ const PostPage = async ({ params }: { params: { slug: string } }) => {
             <span className="h-1 w-1 rounded-full bg-zinc-400"></span>
             <div className="flex items-center gap-1">
               <Clock />
-              <p>{post.readingTime} minutos</p>
+              <p>
+                {post.readingTime} {dictionary.post.readingTimeSuffix}
+              </p>
             </div>
           </div>
         </div>
@@ -110,7 +118,7 @@ const PostPage = async ({ params }: { params: { slug: string } }) => {
           dangerouslySetInnerHTML={{ __html: post.content }}
         />
         <div className="mt-24 mb-10 flex justify-center">
-          <span className="">&copy; 2025 Ian Araujo</span>
+          <span className="">{dictionary.footer.copyright}</span>
         </div>
       </div>
     </div>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -4,6 +4,7 @@ import matter from "gray-matter";
 import Link from "next/link";
 
 import { Header } from "@/components/Header";
+import { DEFAULT_LOCALE, getDictionary } from "@/i18n/dictionaries";
 import { PostMeta } from "@/types";
 import { parseDateString } from "@/utils/getPostImage";
 
@@ -11,17 +12,18 @@ const getPosts = async (): Promise<PostMeta[]> => {
   const postsDirectory = path.join(process.cwd(), "src", "posts");
   const filenames = fs.readdirSync(postsDirectory);
 
-  const posts = filenames.map((filename) => {
-    const filePath = path.join(postsDirectory, filename);
-    const fileContents = fs.readFileSync(filePath, "utf8");
+  const posts = filenames
+    .map((filename) => {
+      const filePath = path.join(postsDirectory, filename);
+      const fileContents = fs.readFileSync(filePath, "utf8");
 
-    const { data } = matter(fileContents);
-    const slug = filename.replace(".md", "");
+      const { data } = matter(fileContents);
+      const slug = filename.replace(".md", "");
 
-    return { ...data, slug } as PostMeta;
-  })
-  // Filter out posts with missing or invalid date
-  .filter((post) => post.date && typeof post.date === "string" && post.date.includes("/"));
+      return { ...data, slug } as PostMeta;
+    })
+    // Filter out posts with missing or invalid date
+    .filter((post) => post.date && typeof post.date === "string" && post.date.includes("/"));
 
   posts.sort((a, b) => {
     const dateA = parseDateString(a.date).getTime();
@@ -34,6 +36,8 @@ const getPosts = async (): Promise<PostMeta[]> => {
 
 const Blog = async () => {
   const posts = await getPosts();
+  const lang = DEFAULT_LOCALE;
+  const dictionary = getDictionary(lang);
 
   const postsByYear = posts.reduce((acc, post) => {
     const year = parseDateString(post.date).getFullYear();
@@ -52,7 +56,7 @@ const Blog = async () => {
   return (
     <div className="flex justify-center w-full min-h-screen">
       <div className="mt-10 w-full max-w-screen-md px-8 md:px-0">
-        <Header />
+        <Header dictionary={dictionary.header} />
         <section>
           {years.map((year) => (
             <div key={year} className="mb-12">
@@ -67,13 +71,9 @@ const Blog = async () => {
                   >
                     <div className="space-y-2">
                       <Link href={`/blog/${post.slug}`}>
-                        <h3 className="hover:underline text-lg">
-                          {post.title}
-                        </h3>
+                        <h3 className="hover:underline text-lg">{post.title}</h3>
                       </Link>
-                      <p className="text-zinc-600 text-sm">
-                        {post.description}
-                      </p>
+                      <p className="text-zinc-600 text-sm">{post.description}</p>
                     </div>
                     <div className="flex items-center gap-2 text-sm text-zinc-500 mt-4 mb-1">
                       <div className="flex gap-2">
@@ -90,7 +90,7 @@ const Blog = async () => {
           ))}
         </section>
         <div className="mt-24 mb-10 flex justify-center">
-          <span className="">&copy; 2025 Ian Araujo</span>
+          <span className="">{dictionary.footer.copyright}</span>
         </div>
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,20 @@
 import "../styles/globals.css";
 import type { Metadata } from "next";
 
+import { DEFAULT_LOCALE } from "@/i18n/dictionaries";
+
 export const metadata: Metadata = {
   title: {
     template: "Ian Araujo | %s",
     default: "Ian Araujo",
   },
   description: "Cientista de Dados e IA",
-  metadataBase: new URL('https://ianaraujo.com')
+  metadataBase: new URL("https://ianaraujo.com"),
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en">
+    <html lang={DEFAULT_LOCALE}>
       <body>{children}</body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import matter from "gray-matter";
 import Link from "next/link";
 
 import { Header } from "@/components/Header";
+import { DEFAULT_LOCALE, getDictionary } from "@/i18n/dictionaries";
 import { PostMeta } from "@/types";
 import { parseDateString } from "@/utils/getPostImage";
 
@@ -12,17 +13,18 @@ const getPosts = async (): Promise<PostMeta[]> => {
   const postsDirectory = path.join(process.cwd(), "src", "posts");
   const filenames = fs.readdirSync(postsDirectory);
 
-  const posts = filenames.map((filename) => {
-    const filePath = path.join(postsDirectory, filename);
-    const fileContents = fs.readFileSync(filePath, "utf8");
+  const posts = filenames
+    .map((filename) => {
+      const filePath = path.join(postsDirectory, filename);
+      const fileContents = fs.readFileSync(filePath, "utf8");
 
-    const { data } = matter(fileContents);
-    const slug = filename.replace(".md", "");
+      const { data } = matter(fileContents);
+      const slug = filename.replace(".md", "");
 
-    return { ...data, slug } as PostMeta;
-  })
-  // Filter out posts with missing or invalid date
-  .filter((post) => post.date && typeof post.date === "string" && post.date.includes("/"));
+      return { ...data, slug } as PostMeta;
+    })
+    // Filter out posts with missing or invalid date
+    .filter((post) => post.date && typeof post.date === "string" && post.date.includes("/"));
 
   posts.sort((a, b) => {
     const dateA = parseDateString(a.date).getTime();
@@ -35,67 +37,52 @@ const getPosts = async (): Promise<PostMeta[]> => {
 
 const Home = async () => {
   const posts = await getPosts();
+  const lang = DEFAULT_LOCALE;
+  const dictionary = getDictionary(lang);
 
   return (
     <div className="flex justify-center w-full min-h-screen">
       <div className="mt-10 w-full max-w-screen-md px-8 md:px-0">
-        <Header />
+        <Header dictionary={dictionary.header} />
         <div className="space-y-10">
           {/* Introducing myself */}
           <div className="">
-            <p className="text-xl leading-relaxed text-justify">
-              {`Meu nome é Ian Araujo. Eu sou cientista de dados de profissão e desenvolvedor nas horas vagas. 
-              Por aqui, compartilho alguns textos sobre IA, dados, tecnologia, e outros interesses: finanças, investimentos e empreendedorismo!`}
-            </p>
+            <p className="text-xl leading-relaxed text-justify">{dictionary.home.intro}</p>
           </div>
           {/* Experience */}
           <section>
-            <h2 className="text-xl font-semibold mb-8">Experiência</h2>
+            <h2 className="text-xl font-semibold mb-8">{dictionary.home.experienceTitle}</h2>
             <div className="relative">
               <div className="absolute left-4 top-0 bottom-0 w-px bg-zinc-200"></div>
               <div className="space-y-8">
-                <div className="flex items-start">
-                  <div className="flex items-center justify-center w-8 h-8">
-                    <div className="w-2 h-2 rounded-full bg-zinc-600 z-10"></div>
-                  </div>
-                  <div className="ml-2 space-y-1">
-                    <div className="flex items-center gap-3">
-                      <h3 className="text-base font-semibold">
-                        Cientista de Dados
-                      </h3>
-                      <p className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-100 text-zinc-600 font-semibold">
-                        ATUAL
-                      </p>
+                {dictionary.home.experiences.map((experience, index) => (
+                  <div key={experience.role + experience.company} className="flex items-start">
+                    <div className="flex items-center justify-center w-8 h-8">
+                      <div
+                        className={`w-2 h-2 rounded-full z-10 ${
+                          index === 0 ? "bg-zinc-600" : "bg-zinc-200"
+                        }`}
+                      ></div>
                     </div>
-                    <p className="text-sm text-zinc-600">Ágora Advocacy</p>
+                    <div className="ml-2 space-y-1">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-base font-semibold">{experience.role}</h3>
+                        {experience.isCurrent && (
+                          <p className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-100 text-zinc-600 font-semibold">
+                            {dictionary.home.currentBadge}
+                          </p>
+                        )}
+                      </div>
+                      <p className="text-sm text-zinc-600">{experience.company}</p>
+                    </div>
                   </div>
-                </div>
-                <div className="flex items-start">
-                  <div className="flex items-center justify-center w-8 h-8">
-                    <div className="w-2 h-2 rounded-full bg-zinc-200 z-10"></div>
-                  </div>
-                  <div className="ml-2 space-y-1">
-                    <h3 className="text-base font-semibold">Pesquisador</h3>
-                    <p className="text-sm text-zinc-600">FGV EBAPE</p>
-                  </div>
-                </div>
-                <div className="flex items-start">
-                  <div className="flex items-center justify-center w-8 h-8">
-                    <div className="w-2 h-2 rounded-full bg-zinc-200 z-10"></div>
-                  </div>
-                  <div className="ml-2 space-y-1">
-                    <h3 className="text-base font-semibold">Consultor</h3>
-                    <p className="text-sm text-zinc-600">
-                      Instituto Lima Barreto, Ministério da Educação, TRE-BA
-                    </p>
-                  </div>
-                </div>
+                ))}
               </div>
             </div>
           </section>
           {/* Latest Posts */}
           <section>
-            <h2 className="text-xl font-semibold pt-4 mb-8">Últimas publicações</h2>
+            <h2 className="text-xl font-semibold pt-4 mb-8">{dictionary.home.latestPostsTitle}</h2>
             <ul className="space-y-4">
               {posts.slice(0, 3).map((post) => (
                 <li
@@ -113,17 +100,15 @@ const Home = async () => {
               <div className="mt-6">
                 <Link href="/blog">
                   <span className="text-zinc-600 hover:underline">
-                    Ver todas publicações
+                    {dictionary.home.viewAllPosts}
                   </span>
                 </Link>
               </div>
             )}
           </section>
           <section>
-            <h2 className="text-xl font-semibold mb-8">Contato</h2>
-            <p className="text-lg">
-              {`Vamos trabalhar juntos! Você pode me mandar mensagem em qualquer rede social. 🚀 `}
-            </p>
+            <h2 className="text-xl font-semibold mb-8">{dictionary.home.contactTitle}</h2>
+            <p className="text-lg">{dictionary.home.contactDescription}</p>
             <div className="flex items-center mt-8 gap-3">
               <div className="flex justify-between">
                 <ul className="flex space-x-4">
@@ -132,7 +117,7 @@ const Home = async () => {
                       className="group transition duration-300"
                       href="https://x.com/ianvazaraujo"
                     >
-                      Twitter
+                      {dictionary.header.socials.twitter}
                       <span className="block max-w-0 group-hover:max-w-full transition-all duration-300 h-[2px] bg-zinc-600"></span>
                     </a>
                   </li>
@@ -141,7 +126,7 @@ const Home = async () => {
                       className="group transition duration-300"
                       href="https://github.com/ianaraujo"
                     >
-                      Github
+                      {dictionary.header.socials.github}
                       <span className="block max-w-0 group-hover:max-w-full transition-all duration-300 h-[2px] bg-zinc-600"></span>
                     </a>
                   </li>
@@ -150,7 +135,7 @@ const Home = async () => {
                       className="group transition duration-300"
                       href="https://www.linkedin.com/in/ianvazaraujo/"
                     >
-                      LinkedIn
+                      {dictionary.header.socials.linkedin}
                       <span className="block max-w-0 group-hover:max-w-full transition-all duration-300 h-[2px] bg-zinc-600"></span>
                     </a>
                   </li>
@@ -160,7 +145,7 @@ const Home = async () => {
           </section>
         </div>
         <div className="mt-20 mb-10 flex justify-center">
-          <span className="">&copy; 2025 Ian Araujo</span>
+          <span className="">{dictionary.footer.copyright}</span>
         </div>
       </div>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,20 @@
 import Image from "next/image";
 import Link from "next/link";
 
-export function Header() {
+import { type Dictionary } from "@/i18n/dictionaries";
+
+type HeaderProps = {
+  dictionary: Dictionary["header"];
+};
+
+export function Header({ dictionary }: HeaderProps) {
   return (
     <>
       <div className="flex flex-col space-y-5">
         <Link href={"/"}>
           <Image
             src="/avatar.png"
-            alt="Avatar"
+            alt={dictionary.avatarAlt}
             width={64}
             height={64}
             className="rounded-full"
@@ -16,9 +22,9 @@ export function Header() {
         </Link>
         <div className="space-y-1">
           <Link href={"/"}>
-            <h2 className="text-2xl font-semibold">Ian Vaz Araujo</h2>
+            <h2 className="text-2xl font-semibold">{dictionary.name}</h2>
           </Link>
-          <p className="text-zinc-500">Cientista de Dados e IA</p>
+          <p className="text-zinc-500">{dictionary.role}</p>
         </div>
         {/* Social Media */}
         <div className="flex justify-between">
@@ -28,7 +34,7 @@ export function Header() {
                 className="group transition duration-300"
                 href="https://x.com/ianvazaraujo"
               >
-                Twitter
+                {dictionary.socials.twitter}
                 <span className="block max-w-0 group-hover:max-w-full transition-all duration-300 h-[2px] bg-zinc-600"></span>
               </a>
             </li>
@@ -37,7 +43,7 @@ export function Header() {
                 className="group transition duration-300"
                 href="https://github.com/ianaraujo"
               >
-                Github
+                {dictionary.socials.github}
                 <span className="block max-w-0 group-hover:max-w-full transition-all duration-300 h-[2px] bg-zinc-600"></span>
               </a>
             </li>
@@ -46,7 +52,7 @@ export function Header() {
                 className="group transition duration-300"
                 href="https://www.linkedin.com/in/ianvazaraujo/"
               >
-                LinkedIn
+                {dictionary.socials.linkedin}
                 <span className="block max-w-0 group-hover:max-w-full transition-all duration-300 h-[2px] bg-zinc-600"></span>
               </a>
             </li>
@@ -55,15 +61,11 @@ export function Header() {
                 className="group transition duration-300"
                 href="https://drive.google.com/file/d/1i8qe0hZs5jaBA6oAchXfSnF0NT1GHm34/view?usp=sharing"
               >
-                CV
+                {dictionary.socials.cv}
                 <span className="block max-w-0 group-hover:max-w-full transition-all duration-300 h-[2px] bg-zinc-600"></span>
               </a>
             </li>
           </ul>
-          {/* <ul className="flex space-x-2">
-              <li className="text-zinc-900">PT</li>
-              <li className="text-zinc-300">EN</li>
-            </ul> */}
         </div>
       </div>
       {/* Divider */}

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -1,0 +1,124 @@
+export const locales = ["pt", "en"] as const;
+export type Locale = (typeof locales)[number];
+
+export type ExperienceEntry = {
+  role: string;
+  company: string;
+  isCurrent?: boolean;
+};
+
+export type DictionaryContent = {
+  header: {
+    name: string;
+    role: string;
+    avatarAlt: string;
+    socials: {
+      twitter: string;
+      github: string;
+      linkedin: string;
+      cv: string;
+    };
+  };
+  home: {
+    intro: string;
+    experienceTitle: string;
+    experiences: ExperienceEntry[];
+    currentBadge: string;
+    latestPostsTitle: string;
+    viewAllPosts: string;
+    contactTitle: string;
+    contactDescription: string;
+  };
+  post: {
+    tagLabel: string;
+    readingTimeSuffix: string;
+  };
+  footer: {
+    copyright: string;
+  };
+};
+
+export const DEFAULT_LOCALE: Locale = "pt";
+
+const dictionaries = {
+  pt: {
+    header: {
+      name: "Ian Vaz Araujo",
+      role: "Cientista de Dados e IA",
+      avatarAlt: "Avatar de Ian Vaz Araujo",
+      socials: {
+        twitter: "Twitter",
+        github: "Github",
+        linkedin: "LinkedIn",
+        cv: "CV",
+      },
+    },
+    home: {
+      intro:
+        "Meu nome é Ian Araujo. Eu sou cientista de dados de profissão e desenvolvedor nas horas vagas. Por aqui, compartilho alguns textos sobre IA, dados, tecnologia, e outros interesses: finanças, investimentos e empreendedorismo!",
+      experienceTitle: "Experiência",
+      experiences: [
+        { role: "Cientista de Dados", company: "Ágora Advocacy", isCurrent: true },
+        { role: "Pesquisador", company: "FGV EBAPE" },
+        {
+          role: "Consultor",
+          company: "Instituto Lima Barreto, Ministério da Educação, TRE-BA",
+        },
+      ],
+      currentBadge: "ATUAL",
+      latestPostsTitle: "Últimas publicações",
+      viewAllPosts: "Ver todas publicações",
+      contactTitle: "Contato",
+      contactDescription:
+        "Vamos trabalhar juntos! Você pode me mandar mensagem em qualquer rede social. 🚀",
+    },
+    post: {
+      tagLabel: "Etiqueta",
+      readingTimeSuffix: "minutos",
+    },
+    footer: {
+      copyright: "© 2025 Ian Araujo",
+    },
+  },
+  en: {
+    header: {
+      name: "Ian Vaz Araujo",
+      role: "Data & AI Scientist",
+      avatarAlt: "Avatar of Ian Vaz Araujo",
+      socials: {
+        twitter: "Twitter",
+        github: "Github",
+        linkedin: "LinkedIn",
+        cv: "Resume",
+      },
+    },
+    home: {
+      intro:
+        "My name is Ian Araujo. I am a data scientist by trade and a developer in my spare time. Here I share posts about AI, data, technology, and other interests: finance, investing, and entrepreneurship!",
+      experienceTitle: "Experience",
+      experiences: [
+        { role: "Data Scientist", company: "Ágora Advocacy", isCurrent: true },
+        { role: "Researcher", company: "FGV EBAPE" },
+        { role: "Consultant", company: "Instituto Lima Barreto, Ministério da Educação, TRE-BA" },
+      ],
+      currentBadge: "CURRENT",
+      latestPostsTitle: "Latest posts",
+      viewAllPosts: "View all posts",
+      contactTitle: "Contact",
+      contactDescription:
+        "Let's work together! You can message me on any social network. 🚀",
+    },
+    post: {
+      tagLabel: "Tag",
+      readingTimeSuffix: "minutes",
+    },
+    footer: {
+      copyright: "© 2025 Ian Araujo",
+    },
+  },
+} satisfies Record<Locale, DictionaryContent>;
+
+export type Dictionary = (typeof dictionaries)[Locale];
+
+export const getDictionary = (locale: Locale = DEFAULT_LOCALE): Dictionary =>
+  dictionaries[locale];


### PR DESCRIPTION
## Summary
- add typed pt/en dictionaries with helpers for shared translations and default locale
- localize header, home sections, blog pages, and post chrome strings via dictionary lookups
- set layout language to default locale and add accessibility label for post tags

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942b8e2d6ec832f99b678d3cc5f3454)